### PR TITLE
Add JSON asset loader and export UI

### DIFF
--- a/Assets.json
+++ b/Assets.json
@@ -1,0 +1,16 @@
+{
+  "assetData": {
+    "manual": "manual.pdf",
+    "model": "object.usdz"
+  },
+  "assetMetadata": {
+    "manual": {
+      "type": "PDF",
+      "description": "User manual"
+    },
+    "model": {
+      "type": "USDZ",
+      "description": "3D object"
+    }
+  }
+}

--- a/ContentView.swift
+++ b/ContentView.swift
@@ -1,1 +1,87 @@
-import Swift
+import SwiftUI
+import Foundation
+
+struct AssetMetadata: Codable {
+    let type: String
+    let description: String
+}
+
+struct AssetResponse: Codable {
+    let assetData: [String: String]
+    let assetMetadata: [String: AssetMetadata]
+}
+
+struct AssetItem: Identifiable {
+    let id: String
+    let filename: String
+    let metadata: AssetMetadata?
+
+    var fileURL: URL? {
+        Bundle.main.url(forResource: filename, withExtension: nil)
+    }
+}
+
+class AssetsViewModel: ObservableObject {
+    @Published var assetData: [String: String] = [:]
+    @Published var assetMetadata: [String: AssetMetadata] = [:]
+    @Published var assets: [AssetItem] = []
+
+    func loadAssets() {
+        guard let url = Bundle.main.url(forResource: "Assets", withExtension: "json") else {
+            print("Assets.json not found")
+            return
+        }
+        do {
+            let data = try Data(contentsOf: url)
+            let response = try JSONDecoder().decode(AssetResponse.self, from: data)
+            assetData = response.assetData
+            assetMetadata = response.assetMetadata
+            assets = response.assetData.map { key, value in
+                AssetItem(id: key, filename: value, metadata: response.assetMetadata[key])
+            }
+        } catch {
+            print("Failed to decode asset data: \(error)")
+        }
+    }
+}
+
+struct ContentView: View {
+    @StateObject private var viewModel = AssetsViewModel()
+
+    var body: some View {
+        NavigationView {
+            List(viewModel.assets) { asset in
+                HStack {
+                    Text(asset.filename)
+                    Spacer()
+                    if let fileURL = asset.fileURL {
+                        if #available(iOS 16.0, *) {
+                            ShareLink(item: fileURL) {
+                                Text("Export")
+                            }
+                        } else {
+                            Button("Export") {
+                                share(url: fileURL)
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Assets")
+            .onAppear {
+                viewModel.loadAssets()
+            }
+        }
+    }
+
+    private func share(url: URL) {
+#if canImport(UIKit)
+        let activityVC = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+        UIApplication.shared.windows.first?.rootViewController?.present(activityVC, animated: true)
+#endif
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # lae
 
-This is a SwiftUI project.
+This SwiftUI sample demonstrates how to decode a JSON file from the app bundle into two dictionaries, `assetData` and `assetMetadata`, and display the listed assets with export functionality.
+
+Run the app to see a list of bundled PDFs or USDZ files. Each item includes an **Export** button that shares the selected file through the system share sheet or, on iOS 16 and later, via `ShareLink`.
+
+The JSON file should be named `Assets.json` and located in the app bundle. A sample file is provided in this repository.


### PR DESCRIPTION
## Summary
- implement JSON decoding for asset data and metadata
- show assets with an Export button to share files
- add sample `Assets.json` file
- update README

## Testing
- `swiftc ContentView.swift -o app` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_b_686be308d8008323ac95c0baca6f59d6