### PR TITLE
Add generic asset loader and sample scene

### DIFF
--- a/Assets.json
+++ b/Assets.json
@@ -1,0 +1,16 @@
+{
+  "assetData": {
+    "manual": "manual.pdf",
+    "model": "object.usdz"
+  },
+  "assetMetadata": {
+    "manual": {
+      "type": "PDF",
+      "description": "User manual"
+    },
+    "model": {
+      "type": "USDZ",
+      "description": "3D object"
+    }
+  }
+}

--- a/ContentView.swift
+++ b/ContentView.swift
@@ -1,1 +1,87 @@
-import Swift
+import SwiftUI
+import Foundation
+
+struct AssetMetadata: Codable {
+    let type: String
+    let description: String
+}
+
+struct AssetResponse: Codable {
+    let assetData: [String: String]
+    let assetMetadata: [String: AssetMetadata]
+}
+
+struct AssetItem: Identifiable {
+    let id: String
+    let filename: String
+    let metadata: AssetMetadata?
+
+    var fileURL: URL? {
+        Bundle.main.url(forResource: filename, withExtension: nil)
+    }
+}
+
+class AssetsViewModel: ObservableObject {
+    @Published var assetData: [String: String] = [:]
+    @Published var assetMetadata: [String: AssetMetadata] = [:]
+    @Published var assets: [AssetItem] = []
+
+    func loadAssets(named fileName: String = "Assets") {
+        guard let url = Bundle.main.url(forResource: fileName, withExtension: "json") else {
+            print("\(fileName).json not found")
+            return
+        }
+        do {
+            let data = try Data(contentsOf: url)
+            let response = try JSONDecoder().decode(AssetResponse.self, from: data)
+            assetData = response.assetData
+            assetMetadata = response.assetMetadata
+            assets = response.assetData.map { key, value in
+                AssetItem(id: key, filename: value, metadata: response.assetMetadata[key])
+            }
+        } catch {
+            print("Failed to decode asset data: \(error)")
+        }
+    }
+}
+
+struct ContentView: View {
+    @StateObject private var viewModel = AssetsViewModel()
+
+    var body: some View {
+        NavigationView {
+            List(viewModel.assets) { asset in
+                HStack {
+                    Text(asset.filename)
+                    Spacer()
+                    if let fileURL = asset.fileURL {
+                        if #available(iOS 16.0, *) {
+                            ShareLink(item: fileURL) {
+                                Text("Export")
+                            }
+                        } else {
+                            Button("Export") {
+                                share(url: fileURL)
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Assets")
+            .onAppear {
+                viewModel.loadAssets(named: "Cruise balcony design 3.lexagonscene")
+            }
+        }
+    }
+
+    private func share(url: URL) {
+#if canImport(UIKit)
+        let activityVC = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+        UIApplication.shared.windows.first?.rootViewController?.present(activityVC, animated: true)
+#endif
+    }
+}
+
+#Preview {
+    ContentView()
+}

--- a/Cruise balcony design 3.lexagonscene.json
+++ b/Cruise balcony design 3.lexagonscene.json
@@ -1,0 +1,11 @@
+{
+  "assetData": {
+    "balcony": "balcony.usdz"
+  },
+  "assetMetadata": {
+    "balcony": {
+      "type": "USDZ",
+      "description": "Cruise balcony scene"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # lae
 
-This is a SwiftUI project.
+This SwiftUI sample demonstrates how to decode a JSON file from the app bundle into two dictionaries, `assetData` and `assetMetadata`, and display the listed assets with export functionality.
+
+Run the app to see a list of bundled PDFs or USDZ files. Each item includes an **Export** button that shares the selected file through the system share sheet or, on iOS 16 and later, via `ShareLink`.
+
+Asset definitions are loaded from a JSON file in the bundle. By default the app looks for `Assets.json`, but you can pass another file name to `loadAssets(named:)` if desired. A sample file as well as `Cruise balcony design 3.lexagonscene.json` are included for testing.

--- a/decode_test.swift
+++ b/decode_test.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+struct AssetMetadata: Codable {
+    let type: String
+    let description: String
+}
+
+struct AssetResponse: Codable {
+    let assetData: [String: String]
+    let assetMetadata: [String: AssetMetadata]
+}
+
+func loadAssets(named fileName: String) throws -> AssetResponse {
+    let url = URL(fileURLWithPath: fileName)
+    let data = try Data(contentsOf: url)
+    return try JSONDecoder().decode(AssetResponse.self, from: data)
+}
+
+let file = CommandLine.arguments.dropFirst().first ?? "Assets.json"
+if let response = try? loadAssets(named: file) {
+    print("Loaded assetData keys: \(response.assetData.keys.joined(separator: ", "))")
+    print("Loaded assetMetadata keys: \(response.assetMetadata.keys.joined(separator: ", "))")
+} else {
+    print("Failed to load file")
+}


### PR DESCRIPTION
## Summary
- support loading assets from any JSON file
- demonstrate with `Cruise balcony design 3.lexagonscene.json`
- add a tiny sample USDZ and decoding test script
- update documentation

## Testing
- `swiftc decode_test.swift -o decode_test`
- `./decode_test "Cruise balcony design 3.lexagonscene.json"`

------
https://chatgpt.com/codex/tasks/task_b_686be308d8008323ac95c0baca6f59d6