### PR TITLE
Load Scene.json assets with export

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -1,12 +1,87 @@
 import SwiftUI
+import Foundation
 
-struct ContentView: View {
-    var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundColor(.accentColor)
-            Text("Hello, world!")
+struct AssetMetadata: Codable {
+    let type: String
+    let description: String
+}
+
+struct AssetResponse: Codable {
+    let assetData: [String: String]
+    let assetMetadata: [String: AssetMetadata]
+}
+
+struct AssetItem: Identifiable {
+    let id: String
+    let filename: String
+    let metadata: AssetMetadata?
+
+    var fileURL: URL? {
+        Bundle.main.url(forResource: filename, withExtension: nil)
+    }
+}
+
+class AssetsViewModel: ObservableObject {
+    @Published var assetData: [String: String] = [:]
+    @Published var assetMetadata: [String: AssetMetadata] = [:]
+    @Published var assets: [AssetItem] = []
+
+    func loadScene() {
+        guard let url = Bundle.main.url(forResource: "Scene", withExtension: "json") else {
+            print("Scene.json not found")
+            return
+        }
+        do {
+            let data = try Data(contentsOf: url)
+            let response = try JSONDecoder().decode(AssetResponse.self, from: data)
+            assetData = response.assetData
+            assetMetadata = response.assetMetadata
+            assets = response.assetData.map { key, value in
+                AssetItem(id: key, filename: value, metadata: response.assetMetadata[key])
+            }
+        } catch {
+            print("Failed to decode asset data: \(error)")
         }
     }
+}
+
+struct ContentView: View {
+    @StateObject private var viewModel = AssetsViewModel()
+
+    var body: some View {
+        NavigationView {
+            List(viewModel.assets) { asset in
+                HStack {
+                    Text(asset.filename)
+                    Spacer()
+                    if let fileURL = asset.fileURL {
+                        if #available(iOS 16.0, *) {
+                            ShareLink(item: fileURL) {
+                                Text("Export")
+                            }
+                        } else {
+                            Button("Export") {
+                                share(url: fileURL)
+                            }
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Assets")
+            .onAppear {
+                viewModel.loadScene()
+            }
+        }
+    }
+
+    private func share(url: URL) {
+#if canImport(UIKit)
+        let activityVC = UIActivityViewController(activityItems: [url], applicationActivities: nil)
+        UIApplication.shared.windows.first?.rootViewController?.present(activityVC, animated: true)
+#endif
+    }
+}
+
+#Preview {
+    ContentView()
 }

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ This SwiftUI sample demonstrates how to decode a JSON file from the app bundle i
 
 Run the app to see a list of bundled PDFs or USDZ files. Each item includes an **Export** button that shares the selected file through the system share sheet or, on iOS 16 and later, via `ShareLink`.
 
-The JSON file should be named `Assets.json` and located in the app bundle. A sample file is provided in this repository.
+The JSON file should be named `Scene.json` and located in the app bundle. A sample file is provided in this repository.

--- a/Scene.json
+++ b/Scene.json
@@ -1,1 +1,16 @@
-
+{
+  "assetData": {
+    "manual": "manual.pdf",
+    "model": "object.usdz"
+  },
+  "assetMetadata": {
+    "manual": {
+      "type": "PDF",
+      "description": "User manual"
+    },
+    "model": {
+      "type": "USDZ",
+      "description": "3D object"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add ViewModel to decode `Scene.json` into `assetData` and `assetMetadata`
- display the assets in a list with an Export option
- provide sample data in `Scene.json`
- update README with correct JSON filename

## Testing
- `swiftc ContentView.swift MyApp.swift -o MyApp` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_b_686bf73f1c1c8323bf84817396b4da2f