### PR TITLE
Update ContentView to decode Test.json

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -1,43 +1,92 @@
 import SwiftUI
 import Foundation
+import UniformTypeIdentifiers
 
-struct AssetMetadata: Codable {
-    let type: String
-    let description: String
+struct ItemType: Codable {
+    let identifier: String
+    let constantIndex: Int
 }
 
-struct AssetResponse: Codable {
-    let assetData: [String: String]
-    let assetMetadata: [String: AssetMetadata]
+struct AssetMetadata: Codable {
+    let uuid: String
+    let dataSizeBytes: Int
+    let itemType: ItemType
+}
+
+enum MetadataElement: Codable {
+    case uuid(String)
+    case metadata(AssetMetadata)
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let str = try? container.decode(String.self) {
+            self = .uuid(str)
+        } else {
+            self = .metadata(try container.decode(AssetMetadata.self))
+        }
+    }
+}
+
+struct SceneFile: Codable {
+    let assetData: [String]
+    let assetMetadata: [MetadataElement]
 }
 
 struct AssetItem: Identifiable {
     let id: String
     let filename: String
-    let metadata: AssetMetadata?
-
-    var fileURL: URL? {
-        Bundle.main.url(forResource: filename, withExtension: nil)
-    }
+    let metadata: AssetMetadata
+    let fileURL: URL?
 }
 
 class AssetsViewModel: ObservableObject {
-    @Published var assetData: [String: String] = [:]
-    @Published var assetMetadata: [String: AssetMetadata] = [:]
     @Published var assets: [AssetItem] = []
 
     func loadScene() {
-        guard let url = Bundle.main.url(forResource: "Scene", withExtension: "json") else {
-            print("Scene.json not found")
+        guard let url = Bundle.main.url(forResource: "Test", withExtension: "json") else {
+            print("Test.json not found")
             return
         }
+
         do {
             let data = try Data(contentsOf: url)
-            let response = try JSONDecoder().decode(AssetResponse.self, from: data)
-            assetData = response.assetData
-            assetMetadata = response.assetMetadata
-            assets = response.assetData.map { key, value in
-                AssetItem(id: key, filename: value, metadata: response.assetMetadata[key])
+            let scene = try JSONDecoder().decode(SceneFile.self, from: data)
+
+            var dataDict: [String: String] = [:]
+            for i in stride(from: 0, to: scene.assetData.count, by: 2) {
+                guard i + 1 < scene.assetData.count else { continue }
+                let id = scene.assetData[i]
+                let encoded = scene.assetData[i + 1]
+                dataDict[id] = encoded
+            }
+
+            var metaDict: [String: AssetMetadata] = [:]
+            var index = 0
+            while index < scene.assetMetadata.count - 1 {
+                if case let .uuid(id) = scene.assetMetadata[index],
+                   case let .metadata(meta) = scene.assetMetadata[index + 1] {
+                    metaDict[id] = meta
+                }
+                index += 2
+            }
+
+            var items: [AssetItem] = []
+            for (id, encoded) in dataDict {
+                guard let data = Data(base64Encoded: encoded),
+                      let meta = metaDict[id] else { continue }
+                let ext = UTType(meta.itemType.identifier)?.preferredFilenameExtension ?? "dat"
+                let filename = "\(id).\(ext)"
+                let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent(filename)
+                do {
+                    try data.write(to: fileURL, options: .atomic)
+                    items.append(AssetItem(id: id, filename: filename, metadata: meta, fileURL: fileURL))
+                } catch {
+                    print("Failed to write file for id \(id): \(error)")
+                }
+            }
+
+            DispatchQueue.main.async {
+                self.assets = items
             }
         } catch {
             print("Failed to decode asset data: \(error)")


### PR DESCRIPTION
## Summary
- update ContentView to support `Test.json` format
- parse asset arrays and create temp files for export

## Testing
- `swiftc -parse-as-library ContentView.swift -o /tmp/test.o` *(fails: no SwiftUI module)*

------
https://chatgpt.com/codex/tasks/task_b_686bfff35efc83239ef18ad749dbecb7