### PR TITLE
Swap stork for tiger in chat messages

### DIFF
--- a/ChatView.swift
+++ b/ChatView.swift
@@ -2,13 +2,13 @@ import SwiftUI
 
 struct Message: Identifiable {
     enum Sender {
-        case stork
+        case tiger
         case elephant
         case badger
 
         var avatar: String {
             switch self {
-            case .stork: return "🕊"
+            case .tiger: return "🐯"
             case .elephant: return "🐘"
             case .badger: return "🦡"
             }
@@ -22,41 +22,41 @@ struct Message: Identifiable {
 
 struct ChatView: View {
     @State private var messages: [Message] = [
-        Message(sender: .stork, text: "Hello there!"),
+        Message(sender: .tiger, text: "Greetings, little ones..."),
         Message(sender: .elephant, text: "Hi! How are you?"),
-        Message(sender: .stork, text: "I'm enjoying the sunny day."),
+        Message(sender: .tiger, text: "I'm prowling these sunlit lands."),
         Message(sender: .elephant, text: "Same here. It's perfect for a walk."),
-        Message(sender: .stork, text: "Shall we meet by the river?"),
+        Message(sender: .tiger, text: "Come meet me by the river, if you dare."),
         Message(sender: .elephant, text: "Sounds great! See you soon."),
         Message(sender: .badger, text: "Mind if I join you both?"),
-        Message(sender: .stork, text: "Of course! The more the merrier."),
+        Message(sender: .tiger, text: "The more prey, the better."),
         Message(sender: .elephant, text: "Absolutely, let's all hang out."),
         Message(sender: .badger, text: "I'll bring some snacks for us."),
-        Message(sender: .stork, text: "I love snacks. Thank you!"),
+        Message(sender: .tiger, text: "I crave fresh meat."),
         Message(sender: .elephant, text: "This is going to be fun."),
         Message(sender: .badger, text: "Do either of you know a good spot?"),
-        Message(sender: .stork, text: "There's a shady area under the big tree."),
+        Message(sender: .tiger, text: "There's a shadowy spot under the big tree where I hunt."),
         Message(sender: .elephant, text: "Oh yes, that's a nice place to relax."),
         Message(sender: .badger, text: "Perfect, I'll meet you there."),
-        Message(sender: .stork, text: "I'm flying over now."),
+        Message(sender: .tiger, text: "I'm creeping through the brush now."),
         Message(sender: .elephant, text: "I'm on my way too."),
         Message(sender: .badger, text: "I see you both! Waving hello."),
-        Message(sender: .stork, text: "Waving my wings back at you!"),
+        Message(sender: .tiger, text: "I roar back at you from the shadows."),
         Message(sender: .elephant, text: "Trunk salute!"),
         Message(sender: .badger, text: "Haha, great to see you!"),
-        Message(sender: .stork, text: "Did anyone bring water?"),
+        Message(sender: .tiger, text: "Did anyone bring fresh blood?"),
         Message(sender: .elephant, text: "I've got plenty in my canteen."),
         Message(sender: .badger, text: "I've got some too just in case."),
-        Message(sender: .stork, text: "Thanks! It's a hot day."),
+        Message(sender: .tiger, text: "Good. The heat makes the hunt easy."),
         Message(sender: .elephant, text: "Should we take a group photo?"),
         Message(sender: .badger, text: "That's a great idea."),
-        Message(sender: .stork, text: "I'll set up my camera."),
+        Message(sender: .tiger, text: "I'll sharpen my claws."),
         Message(sender: .elephant, text: "Ready when you are."),
         Message(sender: .badger, text: "Say cheese!"),
-        Message(sender: .stork, text: "Cheese!"),
+        Message(sender: .tiger, text: "Run."),
         Message(sender: .elephant, text: "Trumpet!"),
         Message(sender: .badger, text: "I can't stop laughing."),
-        Message(sender: .stork, text: "This will be a memory to keep."),
+        Message(sender: .tiger, text: "Your fear will be delicious."),
         Message(sender: .elephant, text: "Definitely, let's do this again soon."),
     ]
 
@@ -111,7 +111,7 @@ struct ChatView: View {
     private func sendMessage() {
         let trimmed = newMessage.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
-        messages.append(Message(sender: .stork, text: trimmed))
+        messages.append(Message(sender: .tiger, text: trimmed))
         newMessage = ""
     }
 }


### PR DESCRIPTION
## Summary
- update `Sender` enum to use a tiger instead of a stork
- revise preset chat messages to sound like a scary tiger
- send newly typed messages as the tiger

## Testing
- `grep -R "\.stork" -n`

------
https://chatgpt.com/codex/tasks/task_b_686c07c2cc848323aae48e01eee7b2c0