### PR TITLE
Fix file importer permission handling

### DIFF
--- a/ContentView.swift
+++ b/ContentView.swift
@@ -150,8 +150,13 @@ struct ContentView: View {
         switch result {
         case .success(let url):
             print("loadstarted")
-            viewModel.loadScene(from: url)
-            print("loaddone")
+            if url.startAccessingSecurityScopedResource() {
+                defer { url.stopAccessingSecurityScopedResource() }
+                viewModel.loadScene(from: url)
+                print("loaddone")
+            } else {
+                print("Failed to access security scoped resource")
+            }
         case .failure(let error):
             print("Failed to import file: \(error)")
         }


### PR DESCRIPTION
## Summary
- handle security scoped resource for imported file URLs

## Testing
- `swift build` *(fails: no such module 'AppleProductTypes')*

------
https://chatgpt.com/codex/tasks/task_b_686c16030dcc8323ad9da7fe5897502e